### PR TITLE
add usage field to config.js and check for it in index.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 export const device = {
-  vid: 28263, //vendorId
-  pid: 8499, //productId
-  index: 1, // 0 - ~
+  vid: 22871, //vendorId
+  pid: 256, //productId
+  index: 0, // 0 - ~
+  usage: 6 // keyboard, see https://learn.microsoft.com/en-us/windows-hardware/drivers/hid/hid-usages#usage-id
 };

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ usbDetect.on(`remove:${device.vid}`, async function (d) {
 
 function listener() {
   setTimeout(async function () {
-    doNotify("Qmk Connected ");
+    doNotify("Qmk Connected");
     const devices = HID.devices()
-      .filter((d) => d.vendorId == device.vid && d.productId == device.pid)
+      .filter((d) => d.vendorId == device.vid && d.productId == device.pid && d.usage == device.usage)
       .sort(order);
     let active = new HID.HID(devices[device.index].path);
 


### PR DESCRIPTION
The README mentions multiple devices with the same vendor and product ID... I think this is because a keyboard integrates several devices with different usages... see here https://learn.microsoft.com/en-us/windows-hardware/drivers/hid/hid-usages#usage-id

This PR adds a usage field to the config.js and checks for the usage in index.js - for me this resulted in a single device after filtering, meaning I can leave device.index as 0 - don't need trial and error process of incrementing device.index.

Feel free to edit of course